### PR TITLE
Change the network name

### DIFF
--- a/src/js/defaultConfig.js
+++ b/src/js/defaultConfig.js
@@ -1,2 +1,2 @@
-var networkName = 'Ethereum';
+var networkName = 'Hemi';
 var faviconPath = '/favicon.ico';


### PR DESCRIPTION
This small change will ensure the tab name in the browser says "Hemi" instead of "Ethereum".